### PR TITLE
remove eslint and eslint_d

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,14 +4,15 @@
   "description": "Long running Stylelint daemon",
   "bin": "bin/stylelint_d.js",
   "dependencies": {
-    "eslint": "^3.17.1",
-    "eslint_d": "^4.2.2",
     "glob": "^7.0.5",
     "minimist": "^1.2.0",
     "resolve": "^1.1.7",
     "stylelint": "^7.1.0"
   },
-  "devDependencies": {},
+  "devDependencies": {
+    "eslint": "^4.11.0",
+    "eslint_d": "^5.1.0"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/jo-sm/stylelint_d.git"


### PR DESCRIPTION
I have forked stylelint_d and found that eslint and eslint_d were not used in this project after reviewing the codes. It seems like they were used in development environment.