### PR TITLE
Pass filename to stylelint

### DIFF
--- a/bin/stylelint_d.js
+++ b/bin/stylelint_d.js
@@ -38,6 +38,14 @@ if (args.stdin) {
     return;
   }
 
+  var validSyntaxes = ["scss", "less", "sugarss", "sss"];
+  var recommendedSyntaxes = "scss, less, sugarss";
+  var language = args.language;
+  if (language && validSyntaxes.indexOf(language) === -1) {
+    console.log(`Error: invalid language (${language}). Valid languages: ${recommendedSyntaxes}`);
+    return;
+  }
+
   process.stdin.on('readable', function() {
     var chunk = process.stdin.read();
 

--- a/bin/stylelint_d.js
+++ b/bin/stylelint_d.js
@@ -27,6 +27,7 @@ if (args.version || args.v) {
 var stdin = '';
 var filename = args.file || args.f;
 var config = args.config || args.c;
+var language = args.language;
 
 if (!args.formatter) {
   args.formatter = 'string';
@@ -40,10 +41,14 @@ if (args.stdin) {
 
   var validSyntaxes = ["scss", "less", "sugarss", "sss"];
   var recommendedSyntaxes = "scss, less, sugarss";
-  var language = args.language;
+
   if (language && validSyntaxes.indexOf(language) === -1) {
     console.log(`Error: invalid language (${language}). Valid languages: ${recommendedSyntaxes}`);
     return;
+  }
+
+  if (language && filename) {
+    console.log(`Notice: --language has higher precedence than the extension in the filename.\n${filename} will be parsed with syntax ${language}.`);
   }
 
   process.stdin.on('readable', function() {

--- a/lib/server.js
+++ b/lib/server.js
@@ -152,6 +152,10 @@ function connHandler(conn) {
 
       folder = files[0];
       lintOpts.code = args.stdin;
+
+      if (args.file) {
+        lintOpts.codeFilename = args.file;
+      }
     } else {
       console.info(`Given files: ${files}`);
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -156,6 +156,10 @@ function connHandler(conn) {
       if (args.file) {
         lintOpts.codeFilename = args.file;
       }
+
+      if (args.language) {
+        lintOpts.syntax = args.language;
+      }
     } else {
       console.info(`Given files: ${files}`);
 


### PR DESCRIPTION
When working with stdin, stylelint needs the filename to determine the syntax of the file.

This fixes a bug: all files would be linted as CSS, so SCSS files that are not plain valid CSS files would get a `CssSyntaxError`.