### PR TITLE
Add exit codes

### DIFF
--- a/bin/stylelint_d.js
+++ b/bin/stylelint_d.js
@@ -112,10 +112,27 @@ function lint(args) {
         return;
       }
 
+      // Determine if it's an error, first
+      var errorObject;
+      var parsed;
+      if (data[0] === 'stylelint_d: isError') {
+        errorObject = data[1];
+
+        try {
+          parsed = JSON.parse(errorObject);
+        } catch(e) {
+          throw new Error('Unknown error occurred.');
+        }
+
+        process.exitCode = parsed.code;
+
+        console.log(parsed.message);
+
+        return;
+      }
+
       if (format === 'string') {
         var result = data.join('');
-        var parsed;
-
 
         try {
           parsed = JSON.parse(result);
@@ -124,6 +141,8 @@ function lint(args) {
 
           console.log('Error: Could not parse `stylelint_d` result');
           console.error(e);
+
+          return;
         }
 
         var didErrored = parsed.errored;

--- a/lib/server.js
+++ b/lib/server.js
@@ -232,8 +232,26 @@ function connHandler(conn) {
       .catch(function(error) {
         console.info(`Could not lint: ${error}`);
 
-        var errorObject = generateError(error, formatter);
-        conn.write(JSON.stringify(errorObject));
+        // If the error code is 78, it's due to a configuration error
+        // If the error code is 80, it's a glob error
+        // 78 -> 3, 80 -> 4, (other) -> 5
+
+        var errorCode;
+        if (error.code === 78) {
+          errorCode = 3;
+        } else if (error.code === 80) {
+          errorCode = 4;
+        } else if (Number.isInteger(error.code)) {
+          errorCode = 5;
+        }
+
+        var errorObject = {
+          message: generateError(error, formatter),
+          code: errorCode
+        };
+
+        write(conn, 'stylelint_d: isError');
+        write(conn, JSON.stringify(errorObject));
       })
       .then(function() {
         // Finally, close the connection

--- a/lib/server.js
+++ b/lib/server.js
@@ -166,7 +166,11 @@ function connHandler(conn) {
         if (formatter === 'string') {
           // If the formatter is a string, we just send the raw output
           // from stylelint, since it's formatted for us already.
-          result = JSON.stringify(data.output);
+          result = JSON.stringify({
+            output: data.output,
+            errored: data.errored
+          });
+
           write(conn, result);
         } else {
           // To handle large data, we spread out sending the resulting
@@ -213,6 +217,14 @@ function connHandler(conn) {
               var warning = warnings[l];
 
               write(conn, JSON.stringify(warning));
+            }
+
+            // Send exit code
+            write(conn, "stylelint_d: exitCode");
+            if (warnings.length > 0) {
+              write(conn, JSON.stringify(2));
+            } else {
+              write(conn, JSON.stringify(0));
             }
           }
         }


### PR DESCRIPTION
This adds support for exit codes, similarly to the `stylelint` CLI. 

The original `stylelint` CLI supports 4 exit codes:

```
1: Something unknown went wrong.
2: At least one rule with an "error"-level severity triggered at least one violations.
78: There was some problem with the configuration file.
80: A file glob was passed, but it found no files.
```

This pull request adds 5 new exit codes, from 1 to 5, and simplifies the exit codes that are present in `stylelint`:

1. A catch all for all unknown errors that occur within `stylelint_d`, such as invalid JSON or internal messages being sent from the server instance to the client.
2. When the CSS file contains an error (not just a warning).
3. The configuration file has an issue (`stylelint` code 78).
4. A file glob was passed but had no files (`stylelint` code 80).
5. A catch all for other error codes sent from `stylelint` itself.

Thanks to @mukimov for this idea! 