### PR TITLE
Add basic stylelint integration tests

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,5 +1,10 @@
 {
-  "extends": ["eslint:recommended", "plugin:@typescript-eslint/recommended"],
+  "extends": [
+    "eslint:recommended",
+    "plugin:@typescript-eslint/recommended",
+    "plugin:jest/style",
+    "plugin:jest/recommended"
+  ],
   "env": {
     "es6": true,
     "node": true

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+src/fixtures/invalid.css

--- a/package-lock.json
+++ b/package-lock.json
@@ -2324,6 +2324,15 @@
         }
       }
     },
+    "eslint-plugin-jest": {
+      "version": "24.3.6",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-24.3.6.tgz",
+      "integrity": "sha512-WOVH4TIaBLIeCX576rLcOgjNXqP+jNlCiEmRgFTfQtJ52DpwnIQKAVGlGPAN7CZ33bW6eNfHD6s8ZbEUTQubJg==",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/experimental-utils": "^4.0.1"
+      }
+    },
     "eslint-scope": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
@@ -6211,6 +6220,12 @@
           }
         }
       }
+    },
+    "stylelint-config-recommended": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-5.0.0.tgz",
+      "integrity": "sha512-c8aubuARSu5A3vEHLBeOSJt1udOdS+1iue7BmJDTSXoCBmfEQmmWX+59vYIj3NQdJBY6a/QRv1ozVFpaB9jaqA==",
+      "dev": true
     },
     "sugarss": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -24,9 +24,11 @@
     "@typescript-eslint/eslint-plugin": "^4.11.0",
     "@typescript-eslint/parser": "^4.11.0",
     "eslint": "^7.15.0",
+    "eslint-plugin-jest": "^24.3.6",
     "eslint_d": "^10.1.0",
     "jest": "^26.6.3",
     "prettier": "^2.2.1",
+    "stylelint-config-recommended": "^5.0.0",
     "ts-jest": "^26.4.4",
     "typescript": "^4.1.3"
   },
@@ -43,8 +45,8 @@
   "scripts": {
     "build": "tsc",
     "build:watch": "tsc --watch",
-    "lint:eslint": "eslint src/**/* bin/**/*",
-    "lint:prettier": "prettier -c src/**/* bin/**/*",
+    "lint:eslint": "eslint 'src/**/*.ts' 'bin/**/*.ts'",
+    "lint:prettier": "prettier -c 'src/**/*' 'bin/**/*'",
     "lint:types": "tsc --noEmit",
     "test": "jest",
     "test:watch": "jest --watch"

--- a/src/Defer.spec.ts
+++ b/src/Defer.spec.ts
@@ -1,20 +1,20 @@
 import { Defer } from "./Defer";
 
 describe("Defer", () => {
-  it("should resolve the promise once the instance resolve method is called", () => {
+  it("should resolve the promise once the instance resolve method is called", async () => {
     const defer = new Defer<string>();
 
     defer.resolve("success");
 
-    expect(defer.promise).resolves.toBe("success");
+    await expect(defer.promise).resolves.toBe("success");
   });
 
-  it("should reject the promise once the instance reject method is called", () => {
+  it("should reject the promise once the instance reject method is called", async () => {
     const err = new Error("oops");
     const defer = new Defer<string>();
 
     defer.reject(err);
 
-    expect(defer.promise).rejects.toBe(err);
+    await expect(defer.promise).rejects.toBe(err);
   });
 });

--- a/src/Socket.spec.ts
+++ b/src/Socket.spec.ts
@@ -38,7 +38,7 @@ describe("Socket", () => {
       const socket = await Socket.createClientSocket();
 
       expect(socket).toBeInstanceOf(Socket);
-      expect(utils.getNetSocket).toBeCalledTimes(1);
+      expect(utils.getNetSocket).toHaveBeenCalledTimes(1);
     });
 
     it("should attempt to make a new socket until one is successfully created", async () => {
@@ -48,7 +48,7 @@ describe("Socket", () => {
 
       await Socket.createClientSocket();
 
-      expect(utils.getNetSocket).toBeCalledTimes(4);
+      expect(utils.getNetSocket).toHaveBeenCalledTimes(4);
     });
   });
 
@@ -58,9 +58,9 @@ describe("Socket", () => {
 
       new Socket(rawSocket, "client");
 
-      expect(rawSocket.on).toBeCalledWith("data", expect.any(Function));
-      expect(rawSocket.on).toBeCalledWith("close", expect.any(Function));
-      expect(rawSocket.on).toBeCalledWith("end", expect.any(Function));
+      expect(rawSocket.on).toHaveBeenCalledWith("data", expect.any(Function));
+      expect(rawSocket.on).toHaveBeenCalledWith("close", expect.any(Function));
+      expect(rawSocket.on).toHaveBeenCalledWith("end", expect.any(Function));
     });
   });
 
@@ -110,8 +110,8 @@ describe("Socket", () => {
       socket.send(data);
 
       expect(rawSocket.write).toHaveBeenCalledTimes(1);
-      expect(rawSocket.write).toBeCalledWith(utils.encode(data));
-      expect(rawSocket.end).toBeCalled();
+      expect(rawSocket.write).toHaveBeenCalledWith(utils.encode(data));
+      expect(rawSocket.end).toHaveBeenCalled();
     });
 
     it(`should break data that's larger than 512 characters into multiple chunks`, async () => {
@@ -190,15 +190,7 @@ describe("Socket", () => {
       eventHandlers.data(Buffer.from("gibberish"));
       eventHandlers.close();
 
-      let err;
-
-      try {
-        await socket.getData();
-      } catch (e) {
-        err = e;
-      }
-
-      expect(err).toBeInstanceOf(Error);
+      await expect(socket.getData()).rejects.toBeInstanceOf(Error);
     });
 
     it("should resolve with nothing and destroy the socket if no data was sent", async () => {
@@ -208,7 +200,7 @@ describe("Socket", () => {
       eventHandlers.end();
 
       expect(await socket.getData()).toBeUndefined();
-      expect(rawSocket.destroy).toBeCalled();
+      expect(rawSocket.destroy).toHaveBeenCalled();
     });
   });
 });

--- a/src/client.spec.ts
+++ b/src/client.spec.ts
@@ -53,7 +53,7 @@ describe("client", () => {
         message: "stylelint_d started.",
       });
 
-      expect(utils.spawnDaemon).toBeCalled();
+      expect(utils.spawnDaemon).toHaveBeenCalled();
     });
   });
 
@@ -80,7 +80,7 @@ describe("client", () => {
         message: "stylelint_d stopping... ok.",
       });
 
-      expect(socket.send).toBeCalledWith({
+      expect(socket.send).toHaveBeenCalledWith({
         command: Command.STOP,
         cwd: expect.any(String),
         lintArguments: {},
@@ -128,7 +128,7 @@ describe("client", () => {
         message: "stylelint_d restarting... ok.",
       });
 
-      expect(socket.send).toBeCalledWith({
+      expect(socket.send).toHaveBeenCalledWith({
         command: Command.RESTART,
         cwd: expect.any(String),
         lintArguments: {},
@@ -210,7 +210,7 @@ describe("client", () => {
 
       await client(["some/file.css", "some/otherfile.css"]);
 
-      expect(socket.send).toBeCalledWith({
+      expect(socket.send).toHaveBeenCalledWith({
         command: Command.LINT,
         cwd: expect.any(String),
         lintArguments: {
@@ -225,7 +225,7 @@ describe("client", () => {
 
       await client(["--quiet", "some/file.css"]);
 
-      expect(socket.send).toBeCalledWith({
+      expect(socket.send).toHaveBeenCalledWith({
         command: Command.LINT,
         cwd: expect.any(String),
         lintArguments: {
@@ -241,13 +241,13 @@ describe("client", () => {
     it("should read from stdin if no files are given, even if another flag is passed", async () => {
       await client(["--quiet"]);
 
-      expect(utils.readStdin).toBeCalledTimes(1);
+      expect(utils.readStdin).toHaveBeenCalledTimes(1);
     });
 
     it("should read from stdin if the stdin flag is passed", async () => {
       await client(["--stdin"]);
 
-      expect(utils.readStdin).toBeCalledTimes(1);
+      expect(utils.readStdin).toHaveBeenCalledTimes(1);
     });
 
     it("should set the provided stdin text as the code argument", async () => {
@@ -257,7 +257,7 @@ describe("client", () => {
 
       await client(["--stdin", "--stdin-filename", "/path/to/some/filename.css"]);
 
-      expect(socket.send).toBeCalledWith({
+      expect(socket.send).toHaveBeenCalledWith({
         command: Command.LINT,
         cwd: expect.any(String),
         lintArguments: {
@@ -273,7 +273,7 @@ describe("client", () => {
 
       await client(["/some/css/file.css", "--stdin-filename", "/path/to/some/filename.css"]);
 
-      expect(socket.send).toBeCalledWith({
+      expect(socket.send).toHaveBeenCalledWith({
         command: Command.LINT,
         cwd: expect.any(String),
         lintArguments: {
@@ -288,7 +288,7 @@ describe("client", () => {
 
       await client(["file.css", "--config", "/config/file.json"]);
 
-      expect(socket.send).toBeCalledWith({
+      expect(socket.send).toHaveBeenCalledWith({
         command: Command.LINT,
         cwd: expect.any(String),
         lintArguments: {
@@ -303,7 +303,7 @@ describe("client", () => {
       // We don't test the output here because file.json will not resolve to a real file when testing
       await client(["file.css", "--config", "file.json"]);
 
-      expect(resolve.sync).toBeCalled();
+      expect(resolve.sync).toHaveBeenCalled();
     });
 
     it("should turn the config file path into an absolute path if it is relative", async () => {
@@ -311,7 +311,7 @@ describe("client", () => {
 
       await client(["file.css", "--config", "file.json"]);
 
-      expect(socket.send).toBeCalledWith({
+      expect(socket.send).toHaveBeenCalledWith({
         command: Command.LINT,
         cwd: expect.any(String),
         lintArguments: {
@@ -327,7 +327,7 @@ describe("client", () => {
 
       await client(["file.css", "--config-basedir", "/some/configbasedir"]);
 
-      expect(socket.send).toBeCalledWith({
+      expect(socket.send).toHaveBeenCalledWith({
         command: Command.LINT,
         cwd: expect.any(String),
         lintArguments: {
@@ -343,23 +343,7 @@ describe("client", () => {
 
       await client(["file.css", "--config-basedir", "configbasedir"]);
 
-      expect(socket.send).toBeCalledWith({
-        command: Command.LINT,
-        cwd: expect.any(String),
-        lintArguments: {
-          files: ["file.css"],
-          configBasedir: `${process.cwd()}/configbasedir`,
-          formatter: "string",
-        },
-      });
-    });
-
-    it("should make the config basedir argument absolute if it is a relative path", async () => {
-      const { socket } = setup();
-
-      await client(["file.css", "--config-basedir", "configbasedir"]);
-
-      expect(socket.send).toBeCalledWith({
+      expect(socket.send).toHaveBeenCalledWith({
         command: Command.LINT,
         cwd: expect.any(String),
         lintArguments: {
@@ -375,7 +359,7 @@ describe("client", () => {
 
       await client(["file.css", "--custom-formatter", "/some/custom/formatter.js"]);
 
-      expect(socket.send).toBeCalledWith({
+      expect(socket.send).toHaveBeenCalledWith({
         command: Command.LINT,
         cwd: expect.any(String),
         lintArguments: {
@@ -389,7 +373,7 @@ describe("client", () => {
     it("should attempt to resolve the customFromatter file if it's relative", async () => {
       await client(["file.css", "--custom-formatter", "formatter.js"]);
 
-      expect(resolve.sync).toBeCalled();
+      expect(resolve.sync).toHaveBeenCalled();
     });
 
     it("should add make the customFormatter path absolute if it's relative", async () => {
@@ -397,7 +381,7 @@ describe("client", () => {
 
       await client(["file.css", "--custom-formatter", "formatter.js"]);
 
-      expect(socket.send).toBeCalledWith({
+      expect(socket.send).toHaveBeenCalledWith({
         command: Command.LINT,
         cwd: expect.any(String),
         lintArguments: {

--- a/src/fixtures/invalid.css
+++ b/src/fixtures/invalid.css
@@ -1,0 +1,6 @@
+div {
+  color: #ff;
+
+p {
+  padding:  10px;
+}

--- a/src/fixtures/not-ok.css
+++ b/src/fixtures/not-ok.css
@@ -1,0 +1,3 @@
+div {
+  color: #ff;
+}

--- a/src/fixtures/ok.css
+++ b/src/fixtures/ok.css
@@ -1,0 +1,3 @@
+div {
+  color: #fff;
+}

--- a/src/fixtures/stylelint.config.json
+++ b/src/fixtures/stylelint.config.json
@@ -1,0 +1,3 @@
+{
+  "extends": "stylelint-config-recommended"
+}

--- a/src/utils.spec.ts
+++ b/src/utils.spec.ts
@@ -104,7 +104,7 @@ describe("utils", () => {
 
       socketOnceHandlers.connect();
 
-      expect(promise).resolves.toBe(true);
+      await expect(promise).resolves.toBe(true);
     });
 
     it("should resolve false if the socket fails to conenct to the server", async () => {
@@ -112,7 +112,7 @@ describe("utils", () => {
 
       socketOnceHandlers.error();
 
-      expect(promise).resolves.toBe(false);
+      await expect(promise).resolves.toBe(false);
     });
   });
 
@@ -135,7 +135,7 @@ describe("utils", () => {
 
       socketOnceHandlers.connect();
 
-      expect(promise).rejects.toThrow();
+      await expect(promise).rejects.toThrow();
     });
   });
 
@@ -156,7 +156,7 @@ describe("utils", () => {
 
       socketOnceHandlers.error();
 
-      expect(promise).rejects.toThrow();
+      await expect(promise).rejects.toThrow();
     });
   });
 });


### PR DESCRIPTION
This PR adds a few basic `stylelint` integration tests, to ensure that automated tests can catch fundamental broken functionality in a stylelint upgrade. 