### PR TITLE
fix(package): 🐛 Missing files in published pkg

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "2.2.0",
   "description": "Long running Stylelint daemon",
   "bin": "dist/bin/stylelint_d.js",
+  "files": [
+	  "dist/**/*"
+  ],
   "dependencies": {
     "glob": "^7.0.5",
     "lodash.camelcase": "^4.3.0",


### PR DESCRIPTION
The build files from `./dist` are not being included with the published package.

More info:
https://docs.npmjs.com/cli/v6/configuring-npm/package-json#files

Fixes: #100