### PR TITLE
Fix `mocked` warning from `ts-jest`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,10 +33,10 @@
         "eslint": "^8.1.0",
         "eslint_d": "^11.0.0",
         "eslint-plugin-jest": "^26.0.0",
-        "jest": "^27.3.1",
+        "jest": "^27.4.7",
         "prettier": "^2.2.1",
         "stylelint-config-recommended": "^6.0.0",
-        "ts-jest": "^27.0.7",
+        "ts-jest": "^27.1.3",
         "typescript": "^4.1.3"
       }
     },

--- a/package.json
+++ b/package.json
@@ -25,10 +25,10 @@
     "eslint": "^8.1.0",
     "eslint_d": "^11.0.0",
     "eslint-plugin-jest": "^26.0.0",
-    "jest": "^27.3.1",
+    "jest": "^27.4.7",
     "prettier": "^2.2.1",
     "stylelint-config-recommended": "^6.0.0",
-    "ts-jest": "^27.0.7",
+    "ts-jest": "^27.1.3",
     "typescript": "^4.1.3"
   },
   "repository": {

--- a/src/client.spec.ts
+++ b/src/client.spec.ts
@@ -1,5 +1,3 @@
-import { mocked } from "ts-jest/utils";
-
 import { Command } from "./types";
 import { version as packageVersion } from "../package.json";
 import * as _utils from "./utils";
@@ -14,7 +12,7 @@ jest.mock("./utils", () => ({
   daemonRunning: jest.fn(),
 }));
 
-const utils = mocked(_utils);
+const utils = jest.mocked(_utils);
 const MockedSocket = Socket as jest.MockedClass<typeof Socket>;
 
 describe("client", () => {


### PR DESCRIPTION
This PR upgrades `jest` and `ts-jest` to latest, and uses `jest.mocked` instead of `mocked` from `ts-jest/utils` based on this warning coming from `ts-jest`:

> `mocked` util function is now deprecated and has been moved to Jest repository, see https://github.com/facebook/jest/pull/12089. In `ts-jest` v28.0.0, `mocked` function will be completely removed. Users are encouraged to use to Jest v27.4.0 or above to have `mocked` function available from `jest-mock`. One can disable this warning by setting environment variable process.env.DISABLE_MOCKED_WARNING=true
